### PR TITLE
Fix [App ID] Column Type on DashboardAsAdmin

### DIFF
--- a/Power BI API/Power BI API/PBIAPI.pq
+++ b/Power BI API/Power BI API/PBIAPI.pq
@@ -960,7 +960,7 @@ let
 	convertToRecords = Table.ExpandListColumn(trimColumns, "dashboards"),
 	expandRecords = Table.ExpandRecordColumn(convertToRecords, "dashboards", {"id", "displayName", "isReadOnly", "appId"}, {"Dashboard ID", "Dashboard Name", "Is Read Only", "App ID"}),
 	filterNoDashboards = Table.SelectRows(expandRecords, each ([Dashboard ID] <> null)),
-	changeType = Table.TransformColumnTypes(filterNoDashboards,{{"Dashboard ID", type text}, {"Dashboard Name", type text}, {"Is Read Only", type logical}, {"App ID", type logical}})
+	changeType = Table.TransformColumnTypes(filterNoDashboards,{{"Dashboard ID", type text}, {"Dashboard Name", type text}, {"Is Read Only", type logical}, {"App ID", type text}})
 in
 	changeType;
 


### PR DESCRIPTION
It has the incorrect type for the column set as default and it produce errors on all values returned.

Evidence:
<img width="831" alt="image" src="https://github.com/migueesc123/PowerBIRESTAPI/assets/9602911/d3becd67-721d-4f2c-b778-aa3f23758119">
