### PR TITLE
Update execute query function

### DIFF
--- a/Power BI API/PowerBIRESTAPI/PBIAPI.pq
+++ b/Power BI API/PowerBIRESTAPI/PBIAPI.pq
@@ -417,17 +417,17 @@ ExecuteQuery =
                         output =
                             let
                                 initSource = apiCall[results]?{0}?[tables]?{0}?[rows]?,
-                                namesOfColumns = List.Buffer(Record.FieldNames(initSource{0})),
+                                
+                                namesOfColumns = List.Distinct(Record.FieldNames(Record.Combine(initSource))),
                                 correctedColumnsNames =
                                     List.Transform(
                                         namesOfColumns,
-                                        each Text.BetweenDelimiters(_, "[", "]")
+                                        each {_, Text.BetweenDelimiters(_, "[", "]")}
                                     ),
-                                tableCreator = Table.FromList(
-                                        initSource,
-                                        Record.FieldValues,
-                                        correctedColumnsNames
-                                    )
+                                    
+                                padMissingColumns = List.Transform(initSource, each Record.SelectFields(_, namesOfColumns, MissingField.UseNull)),
+                                renameColumns = List.Transform(padMissingColumns, each Record.RenameFields(_, correctedColumnsNames)),
+                                tableCreator = Table.FromRecords(renameColumns)
                             in
                                 tableCreator
                     in

--- a/Power BI API/PowerBIRESTAPI/PBIAPI.pq
+++ b/Power BI API/PowerBIRESTAPI/PBIAPI.pq
@@ -418,7 +418,7 @@ ExecuteQuery =
                             let
                                 initSource = apiCall[results]?{0}?[tables]?{0}?[rows]?,
                                 
-                                namesOfColumns = List.Distinct(Record.FieldNames(Record.Combine(initSource))),
+                                namesOfColumns = List.Buffer(List.Distinct(Record.FieldNames(Record.Combine(initSource)))),
                                 correctedColumnsNames =
                                     List.Transform(
                                         namesOfColumns,


### PR DESCRIPTION
This small PR updates the ExecuteQuery call so that all fields are returned in the result table, versus just the ones in the first row.

It's possible for the first object of the returned JSON to not include all possible columns. This can result in the following errors in Power Query:
![image](https://github.com/user-attachments/assets/bb53aa0c-d48a-40e6-b728-84e9ba890ca4)
![{E1241472-DE8C-4250-B043-11CF0758780D}](https://github.com/user-attachments/assets/47fd6ce7-2d77-4f5a-937a-9c0d0e83b2d7)

In my case, when calling INFO.EXPRESSIONS(), the first two rows did not contain the QueryGroupID field, which caused the table to be created without it. The other rows then started to include it, causing them to error out.

This PR implements a solution similar to the one posted [here](https://community.fabric.microsoft.com/t5/Power-Query/Table-FromRecords-does-not-show-all-columns/m-p/3299850/highlight/true#M106447), by first combining all of the records and pulling the distinct list of field names from the result. The records are then padded with any missing fields before returning the final result.

![image](https://github.com/user-attachments/assets/a15da5b2-aab1-45ac-8361-82229b6d32cc)


I'm guessing this is mostly applicable when running queries against INFO functions.